### PR TITLE
build: Allow building with Oracle JDK 8

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -158,7 +158,7 @@ javac_version_str := $(shell unset _JAVA_OPTIONS && javac -version 2>&1)
 ifneq ($(EXPERIMENTAL_USE_JAVA8),)
 required_version := "1.8.x"
 required_javac_version := "1.8"
-java_version := $(shell echo '$(java_version_str)' | grep 'openjdk .*[ "]1\.8[\. "$$]')
+java_version := $(shell echo '$(java_version_str)' | grep '.*[ "]1\.8[\. "$$]')
 javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.8[\. "$$]')
 else # default
 required_version := "1.7.x"
@@ -185,9 +185,6 @@ endif
 #
 # For Java 1.7, we require OpenJDK on linux and Oracle JDK on Mac OS.
 requires_openjdk := false
-ifeq ($(HOST_OS), linux)
-requires_openjdk := true
-endif
 
 
 # Check for the current jdk


### PR DESCRIPTION
 * The script is currently limiting JDK 8 builds to OpenJDK. Remove
   this political stuff. The Oracle JDK works just fine, performs
   better than OpenJDK in many cases, and there is no reason to require
   switching around just to build Android.

Change-Id: I8200624ca7ccd0624a1aad6ccdb889b433d528d6