### PR TITLE
Revert "build: Allow building with Oracle JDK 8"

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -158,7 +158,7 @@ javac_version_str := $(shell unset _JAVA_OPTIONS && javac -version 2>&1)
 ifneq ($(EXPERIMENTAL_USE_JAVA8),)
 required_version := "1.8.x"
 required_javac_version := "1.8"
-java_version := $(shell echo '$(java_version_str)' | grep '.*[ "]1\.8[\. "$$]')
+java_version := $(shell echo '$(java_version_str)' | grep 'openjdk .*[ "]1\.8[\. "$$]')
 javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.8[\. "$$]')
 else # default
 required_version := "1.7.x"
@@ -185,6 +185,9 @@ endif
 #
 # For Java 1.7, we require OpenJDK on linux and Oracle JDK on Mac OS.
 requires_openjdk := false
+ifeq ($(HOST_OS), linux)
+requires_openjdk := true
+endif
 
 
 # Check for the current jdk


### PR DESCRIPTION
Breaks build servers - See DONUTS-13

This reverts commit a097018341040759bbb0e4bdb11e5288d2e536f1.

Change-Id: I54269dd783e94621de1ff6fa40db2f582aa90334